### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,120 @@
+name: Deploy site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up GitHub Pages
+        uses: actions/configure-pages@v4
+
+      - name: Build static site
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install markdown
+          python - <<'PY'
+import markdown
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[2]
+readme = root / 'README.md'
+site_dir = root / 'dist'
+site_dir.mkdir(exist_ok=True)
+html_body = markdown.markdown(
+    readme.read_text(encoding='utf-8'),
+    extensions=[
+        'fenced_code',
+        'tables',
+        'toc',
+        'sane_lists',
+    ],
+)
+(site_dir / 'index.html').write_text(f'''<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>256t.org</title>
+  <style>
+    :root {{
+      color-scheme: light dark;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.6;
+    }}
+    body {{
+      margin: 0 auto;
+      padding: 2rem 1.5rem 4rem;
+      max-width: 70ch;
+    }}
+    pre {{
+      padding: 1rem;
+      overflow-x: auto;
+      border-radius: 0.5rem;
+      background: rgba(0, 0, 0, 0.05);
+    }}
+    code {{
+      font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    }}
+    table {{
+      border-collapse: collapse;
+      width: 100%;
+      overflow: hidden;
+    }}
+    th, td {{
+      border: 1px solid rgba(125, 125, 125, 0.4);
+      padding: 0.5rem;
+      text-align: left;
+    }}
+    thead {{
+      background: rgba(0, 0, 0, 0.08);
+    }}
+    a {{
+      color: inherit;
+    }}
+    a:hover, a:focus {{
+      text-decoration: underline;
+    }}
+  </style>
+</head>
+<body>
+{html_body}
+</body>
+</html>
+''', encoding='utf-8')
+
+hash_src = root / 'hash.html'
+(site_dir / 'hash.html').write_text(hash_src.read_text(encoding='utf-8'), encoding='utf-8')
+PY
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that converts the README into an index page
- copy the hash tool page into the deployment artifact and publish it to GitHub Pages

## Testing
- not run (workflow only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918d524f7788331813b22acaa12384d)