### PR TITLE
Improve hash tool display and fragment output

### DIFF
--- a/hash.html
+++ b/hash.html
@@ -58,22 +58,31 @@
       padding: 1rem 1.5rem;
       border-radius: 0.75rem;
       word-break: break-all;
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
     }
     dl {
       margin: 0;
-      display: grid;
-      grid-template-columns: max-content 1fr;
-      column-gap: 1.5rem;
-      row-gap: 0.75rem;
-      align-items: start;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    dl > div {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
     }
     dt {
       font-weight: 600;
     }
+    dd {
+      margin: 0;
+    }
     .error {
       color: #c62828;
       font-weight: 600;
-      margin: 1rem 0 0;
+      margin: 0;
     }
   </style>
 </head>
@@ -89,12 +98,24 @@
   <section class="output" aria-live="polite" aria-atomic="true">
     <dl>
       <div>
-        <dt>Hash (Base64URL)</dt>
+        <dt>Content length</dt>
+        <dd id="byteLength">0 bytes</dd>
+      </div>
+      <div>
+        <dt>Base64 length</dt>
+        <dd id="base64Length">AAAAAAAA</dd>
+      </div>
+      <div>
+        <dt>SHA-512 (Base64URL)</dt>
         <dd id="hashValue">—</dd>
       </div>
       <div>
-        <dt>Content length</dt>
-        <dd><span id="byteLength">0</span> bytes</dd>
+        <dt>First 64 chars (Base64URL)</dt>
+        <dd id="prefixValue">—</dd>
+      </div>
+      <div>
+        <dt>Full fragment</dt>
+        <dd id="fragmentValue">AAAAAAAA</dd>
       </div>
     </dl>
     <p id="error" class="error" hidden></p>
@@ -104,7 +125,39 @@
     const input = document.getElementById('inputText');
     const hashValue = document.getElementById('hashValue');
     const byteLength = document.getElementById('byteLength');
+    const base64LengthEl = document.getElementById('base64Length');
+    const prefixValue = document.getElementById('prefixValue');
+    const fragmentValue = document.getElementById('fragmentValue');
     const errorEl = document.getElementById('error');
+
+    const CHUNK_SIZE = 0x8000;
+
+    const toBase64Url = (bytes) => {
+      if (!bytes.length) {
+        return '';
+      }
+      let binary = '';
+      for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+        const chunk = bytes.subarray(i, i + CHUNK_SIZE);
+        binary += String.fromCharCode(...chunk);
+      }
+      return btoa(binary)
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+    };
+
+    const encodeLength = (length) => {
+      let remaining = Math.max(0, Math.floor(length));
+      const bytes = new Uint8Array(6);
+      for (let i = 5; i >= 0; i -= 1) {
+        bytes[i] = remaining % 256;
+        remaining = Math.floor(remaining / 256);
+      }
+      return toBase64Url(bytes);
+    };
+
+    const formatByteLabel = (length) => `${length} byte${length === 1 ? '' : 's'}`;
 
     if (!window.crypto || !window.crypto.subtle) {
       errorEl.textContent = 'This browser does not support the Web Crypto API required to compute hashes.';
@@ -113,28 +166,42 @@
       input.disabled = true;
     } else {
       const encoder = new TextEncoder();
+      let latestRequest = 0;
 
       async function updateHash(text) {
+        const requestId = ++latestRequest;
         try {
           errorEl.hidden = true;
           const data = encoder.encode(text);
-          byteLength.textContent = data.length;
+          byteLength.textContent = formatByteLabel(data.length);
 
-          if (!text) {
-            hashValue.textContent = '—';
-            return;
-          }
+          const lengthBase64 = encodeLength(data.length);
+          base64LengthEl.textContent = lengthBase64;
+
+          const firstSixtyFour = text.slice(0, 64);
+          const prefixBytes = encoder.encode(firstSixtyFour);
+          const prefixBase64 = prefixBytes.length ? toBase64Url(prefixBytes) : '—';
+          prefixValue.textContent = prefixBase64;
+
+          const contentBase64 = data.length && data.length <= 64 ? toBase64Url(data) : '';
 
           const buffer = await crypto.subtle.digest('SHA-512', data);
+          if (requestId !== latestRequest) {
+            return;
+          }
           const hashBytes = new Uint8Array(buffer);
-          const binary = String.fromCharCode(...hashBytes);
-          const base64 = btoa(binary)
-            .replace(/\+/g, '-')
-            .replace(/\//g, '_')
-            .replace(/=+$/, '');
-          hashValue.textContent = base64;
+          const hashBase64 = toBase64Url(hashBytes);
+          hashValue.textContent = hashBase64;
+
+          const fragmentSuffix = data.length <= 64 ? contentBase64 : hashBase64;
+          fragmentValue.textContent = `${lengthBase64}${fragmentSuffix}`;
         } catch (error) {
+          if (requestId !== latestRequest) {
+            return;
+          }
           hashValue.textContent = '—';
+          prefixValue.textContent = '—';
+          fragmentValue.textContent = '—';
           errorEl.textContent = `Unable to compute hash: ${error.message}`;
           errorEl.hidden = false;
         }


### PR DESCRIPTION
## Summary
- lay out each statistic on its own line to stop the hash output from reflowing while typing
- add Base64 length, Base64 preview of the first 64 characters, and the spec-compliant fragment (length+hash/content) using URL-safe Base64
- update the hashing script to compute the additional Base64 fields and always show the proper fragment regardless of content length

## Testing
- Not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918f5727cb48331baca9cde01b0576c)