### PR TITLE
Add CID examples and multi-language utilities

### DIFF
--- a/cids/AAAAAAAiSGVsbG8sIGNvbnRlbnQtYWRkcmVzc2FibGUgd29ybGQhCg
+++ b/cids/AAAAAAAiSGVsbG8sIGNvbnRlbnQtYWRkcmVzc2FibGUgd29ybGQhCg
@@ -1,0 +1,1 @@
+Hello, content-addressable world!

--- a/cids/AAAAAAB7DJ2sGpfgCPjGTuCtkf7BdfY1XhwX5CIKxxxCpSRVsRSqv-IuAePr5KmJ_UtgClE6s5hLCZEUxfNbeDLgNVMHvA
+++ b/cids/AAAAAAB7DJ2sGpfgCPjGTuCtkf7BdfY1XhwX5CIKxxxCpSRVsRSqv-IuAePr5KmJ_UtgClE6s5hLCZEUxfNbeDLgNVMHvA
@@ -1,0 +1,1 @@
+Content identifiers pair a length prefix with either embedded data or a hash. This line is long enough to require hashing.

--- a/cids/AAAAAAD2G_y_e-VtcVpuiHYMJM9HUKnckZMY5Fo9ok_GjG7CSvEvK_9GmYpoWaIaSwzOV54k8YlaVunCZTFmyuanFXv4cQ
+++ b/cids/AAAAAAD2G_y_e-VtcVpuiHYMJM9HUKnckZMY5Fo9ok_GjG7CSvEvK_9GmYpoWaIaSwzOV54k8YlaVunCZTFmyuanFXv4cQ
@@ -1,0 +1,2 @@
+Long-form descriptions help demonstrate deterministic identifiers across languages. Each implementation should compute the same CID when given identical content and encoding.
+Line breaks and punctuation need to be preserved to maintain fidelity.

--- a/examples/long_form_overview_of_multilanguage_content_identifier_verification.txt
+++ b/examples/long_form_overview_of_multilanguage_content_identifier_verification.txt
@@ -1,0 +1,2 @@
+Long-form descriptions help demonstrate deterministic identifiers across languages. Each implementation should compute the same CID when given identical content and encoding.
+Line breaks and punctuation need to be preserved to maintain fidelity.

--- a/examples/medium_length_discussion_of_length_prefix_and_hashing_requirements.txt
+++ b/examples/medium_length_discussion_of_length_prefix_and_hashing_requirements.txt
@@ -1,0 +1,1 @@
+Content identifiers pair a length prefix with either embedded data or a hash. This line is long enough to require hashing.

--- a/examples/short_greeting_content_addressable_storage_demo.txt
+++ b/examples/short_greeting_content_addressable_storage_demo.txt
@@ -1,0 +1,1 @@
+Hello, content-addressable world!

--- a/implementations/deno/check.ts
+++ b/implementations/deno/check.ts
@@ -1,0 +1,25 @@
+import { CIDS_DIR, computeCid } from "./cid.ts";
+
+let mismatches = 0;
+let count = 0;
+
+for await (const entry of Deno.readDir(CIDS_DIR)) {
+  if (entry.isDirectory) {
+    continue;
+  }
+  count += 1;
+  const path = `${CIDS_DIR}/${entry.name}`;
+  const content = await Deno.readFile(path);
+  const expected = await computeCid(content);
+  if (expected !== entry.name) {
+    console.log(`${entry.name} should be ${expected}`);
+    mismatches += 1;
+  }
+}
+
+if (mismatches) {
+  console.error(`Found ${mismatches} mismatched CID file(s).`);
+  Deno.exit(1);
+}
+
+console.log(`All ${count} CID files match their contents.`);

--- a/implementations/deno/cid.ts
+++ b/implementations/deno/cid.ts
@@ -1,0 +1,30 @@
+const toBase64Url = (bytes: Uint8Array): string => {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+};
+
+export const BASE_DIR = new URL("../..", import.meta.url).pathname;
+export const EXAMPLES_DIR = `${BASE_DIR}/examples`;
+export const CIDS_DIR = `${BASE_DIR}/cids`;
+
+export const encodeLength = (length: number): string => {
+  const bytes = new Uint8Array(6);
+  let value = length;
+  for (let i = 5; i >= 0; i--) {
+    bytes[i] = value & 0xff;
+    value >>= 8;
+  }
+  return toBase64Url(bytes);
+};
+
+export const computeCid = async (content: Uint8Array): Promise<string> => {
+  const prefix = encodeLength(content.byteLength);
+  if (content.byteLength <= 64) {
+    return `${prefix}${toBase64Url(content)}`;
+  }
+  const hashBuffer = await crypto.subtle.digest("SHA-512", content);
+  return `${prefix}${toBase64Url(new Uint8Array(hashBuffer))}`;
+};

--- a/implementations/deno/generate.ts
+++ b/implementations/deno/generate.ts
@@ -1,0 +1,14 @@
+import { CIDS_DIR, EXAMPLES_DIR, computeCid } from "./cid.ts";
+
+await Deno.mkdir(CIDS_DIR, { recursive: true });
+
+for await (const entry of Deno.readDir(EXAMPLES_DIR)) {
+  if (entry.isDirectory) {
+    continue;
+  }
+  const path = `${EXAMPLES_DIR}/${entry.name}`;
+  const content = await Deno.readFile(path);
+  const cid = await computeCid(content);
+  await Deno.writeFile(`${CIDS_DIR}/${cid}`, content);
+  console.log(`Wrote ${cid} from ${entry.name}`);
+}

--- a/implementations/java/Check.java
+++ b/implementations/java/Check.java
@@ -1,0 +1,27 @@
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class Check {
+    public static void main(String[] args) throws IOException {
+        int mismatches = 0;
+        int count = 0;
+        for (Path path : Files.list(CidUtil.CIDS_DIR).toList()) {
+            if (Files.isDirectory(path)) {
+                continue;
+            }
+            count++;
+            byte[] content = CidUtil.readFile(path);
+            String expected = CidUtil.computeCid(content);
+            if (!path.getFileName().toString().equals(expected)) {
+                System.out.printf("%s should be %s%n", path.getFileName(), expected);
+                mismatches++;
+            }
+        }
+        if (mismatches > 0) {
+            System.err.printf("Found %d mismatched CID file(s).%n", mismatches);
+            System.exit(1);
+        }
+        System.out.printf("All %d CID files match their contents.%n", count);
+    }
+}

--- a/implementations/java/CidUtil.java
+++ b/implementations/java/CidUtil.java
@@ -1,0 +1,51 @@
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public final class CidUtil {
+    private CidUtil() {}
+
+    public static final Path BASE_DIR = Paths.get("").toAbsolutePath();
+    public static final Path EXAMPLES_DIR = BASE_DIR.resolve("examples");
+    public static final Path CIDS_DIR = BASE_DIR.resolve("cids");
+
+    private static String toBase64Url(byte[] data) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(data);
+    }
+
+    public static String encodeLength(long length) {
+        byte[] bytes = new byte[6];
+        for (int i = 5; i >= 0; i--) {
+            bytes[i] = (byte) (length & 0xFF);
+            length >>= 8;
+        }
+        return toBase64Url(bytes);
+    }
+
+    public static String computeCid(byte[] content) {
+        String prefix = encodeLength(content.length);
+        if (content.length <= 64) {
+            return prefix + toBase64Url(content);
+        }
+        try {
+            MessageDigest sha512 = MessageDigest.getInstance("SHA-512");
+            byte[] hash = sha512.digest(content);
+            return prefix + toBase64Url(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-512 not available", e);
+        }
+    }
+
+    public static byte[] readFile(Path path) throws IOException {
+        return Files.readAllBytes(path);
+    }
+
+    public static void writeFile(Path path, byte[] content) throws IOException {
+        Files.createDirectories(path.getParent());
+        Files.write(path, content);
+    }
+}

--- a/implementations/java/Generate.java
+++ b/implementations/java/Generate.java
@@ -1,0 +1,19 @@
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class Generate {
+    public static void main(String[] args) throws IOException {
+        Files.createDirectories(CidUtil.CIDS_DIR);
+        for (Path path : Files.list(CidUtil.EXAMPLES_DIR).toList()) {
+            if (Files.isDirectory(path)) {
+                continue;
+            }
+            byte[] content = CidUtil.readFile(path);
+            String cid = CidUtil.computeCid(content);
+            Path destination = CidUtil.CIDS_DIR.resolve(cid);
+            CidUtil.writeFile(destination, content);
+            System.out.printf("Wrote %s from %s%n", cid, path.getFileName());
+        }
+    }
+}

--- a/implementations/javascript/check.js
+++ b/implementations/javascript/check.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const { CIDS_DIR, computeCid } = require('./cid');
+
+let mismatches = 0;
+let count = 0;
+for (const entry of fs.readdirSync(CIDS_DIR)) {
+  const fullPath = path.join(CIDS_DIR, entry);
+  if (fs.statSync(fullPath).isDirectory()) {
+    continue;
+  }
+  count += 1;
+  const content = fs.readFileSync(fullPath);
+  const expected = computeCid(content);
+  if (expected !== entry) {
+    console.log(`${entry} should be ${expected}`);
+    mismatches += 1;
+  }
+}
+
+if (mismatches) {
+  console.error(`Found ${mismatches} mismatched CID file(s).`);
+  process.exit(1);
+}
+console.log(`All ${count} CID files match their contents.`);

--- a/implementations/javascript/cid.js
+++ b/implementations/javascript/cid.js
@@ -1,0 +1,35 @@
+const crypto = require('crypto');
+const path = require('path');
+
+const BASE_DIR = path.resolve(__dirname, '..', '..');
+const EXAMPLES_DIR = path.join(BASE_DIR, 'examples');
+const CIDS_DIR = path.join(BASE_DIR, 'cids');
+
+const toBase64Url = (buffer) =>
+  buffer
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+
+const encodeLength = (length) => {
+  const bytes = Buffer.alloc(6);
+  bytes.writeUIntBE(length, 0, 6);
+  return toBase64Url(bytes);
+};
+
+const computeCid = (content) => {
+  const prefix = encodeLength(content.length);
+  const suffix =
+    content.length <= 64
+      ? toBase64Url(content)
+      : toBase64Url(crypto.createHash('sha512').update(content).digest());
+  return `${prefix}${suffix}`;
+};
+
+module.exports = {
+  BASE_DIR,
+  EXAMPLES_DIR,
+  CIDS_DIR,
+  computeCid,
+};

--- a/implementations/javascript/generate.js
+++ b/implementations/javascript/generate.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+const { EXAMPLES_DIR, CIDS_DIR, computeCid } = require('./cid');
+
+fs.mkdirSync(CIDS_DIR, { recursive: true });
+
+for (const entry of fs.readdirSync(EXAMPLES_DIR)) {
+  const fullPath = path.join(EXAMPLES_DIR, entry);
+  if (fs.statSync(fullPath).isDirectory()) {
+    continue;
+  }
+  const content = fs.readFileSync(fullPath);
+  const cid = computeCid(content);
+  fs.writeFileSync(path.join(CIDS_DIR, cid), content);
+  console.log(`Wrote ${cid} from ${entry}`);
+}

--- a/implementations/node/check.mjs
+++ b/implementations/node/check.mjs
@@ -1,0 +1,24 @@
+import { readdirSync, statSync, readFileSync } from 'node:fs';
+import { CIDS_DIR, computeCid } from './cid.js';
+
+let mismatches = 0;
+let count = 0;
+for (const entry of readdirSync(CIDS_DIR)) {
+  const fullPath = `${CIDS_DIR}/${entry}`;
+  if (statSync(fullPath).isDirectory()) {
+    continue;
+  }
+  count += 1;
+  const content = readFileSync(fullPath);
+  const expected = computeCid(content);
+  if (expected !== entry) {
+    console.log(`${entry} should be ${expected}`);
+    mismatches += 1;
+  }
+}
+
+if (mismatches) {
+  console.error(`Found ${mismatches} mismatched CID file(s).`);
+  process.exit(1);
+}
+console.log(`All ${count} CID files match their contents.`);

--- a/implementations/node/cid.js
+++ b/implementations/node/cid.js
@@ -1,0 +1,29 @@
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync, readdirSync, mkdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+export const BASE_DIR = resolve(new URL('.', import.meta.url).pathname, '..', '..');
+export const EXAMPLES_DIR = join(BASE_DIR, 'examples');
+export const CIDS_DIR = join(BASE_DIR, 'cids');
+
+const toBase64Url = (buffer) =>
+  buffer
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+
+export const encodeLength = (length) => {
+  const bytes = Buffer.alloc(6);
+  bytes.writeUIntBE(length, 0, 6);
+  return toBase64Url(bytes);
+};
+
+export const computeCid = (content) => {
+  const prefix = encodeLength(content.length);
+  const suffix =
+    content.length <= 64
+      ? toBase64Url(content)
+      : toBase64Url(createHash('sha512').update(content).digest());
+  return `${prefix}${suffix}`;
+};

--- a/implementations/node/generate.mjs
+++ b/implementations/node/generate.mjs
@@ -1,0 +1,15 @@
+import { mkdirSync, readdirSync, readFileSync, writeFileSync, statSync } from 'node:fs';
+import { EXAMPLES_DIR, CIDS_DIR, computeCid } from './cid.js';
+
+mkdirSync(CIDS_DIR, { recursive: true });
+
+for (const entry of readdirSync(EXAMPLES_DIR)) {
+  const fullPath = `${EXAMPLES_DIR}/${entry}`;
+  if (statSync(fullPath).isDirectory()) {
+    continue;
+  }
+  const content = readFileSync(fullPath);
+  const cid = computeCid(content);
+  writeFileSync(`${CIDS_DIR}/${cid}`, content);
+  console.log(`Wrote ${cid} from ${entry}`);
+}

--- a/implementations/python/check.py
+++ b/implementations/python/check.py
@@ -1,0 +1,25 @@
+from cid import CIDS_DIR, compute_cid
+
+
+def main() -> int:
+    mismatches = []
+    count = 0
+    for path in sorted(CIDS_DIR.iterdir()):
+        if path.is_dir():
+            continue
+        count += 1
+        actual = path.name
+        expected = compute_cid(path.read_bytes())
+        if actual != expected:
+            mismatches.append((path, expected))
+    if mismatches:
+        print("Found CID mismatches:")
+        for path, expected in mismatches:
+            print(f"- {path.name} should be {expected}")
+        return 1
+    print(f"All {count} CID files match their contents.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/cid.py
+++ b/implementations/python/cid.py
@@ -1,0 +1,33 @@
+import base64
+import hashlib
+from pathlib import Path
+
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+EXAMPLES_DIR = BASE_DIR / "examples"
+CIDS_DIR = BASE_DIR / "cids"
+
+
+def to_base64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+
+def encode_length(length: int) -> str:
+    return to_base64url(length.to_bytes(6, "big"))
+
+
+def compute_cid(content: bytes) -> str:
+    prefix = encode_length(len(content))
+    if len(content) <= 64:
+        suffix = to_base64url(content)
+    else:
+        suffix = to_base64url(hashlib.sha512(content).digest())
+    return prefix + suffix
+
+
+__all__ = [
+    "BASE_DIR",
+    "EXAMPLES_DIR",
+    "CIDS_DIR",
+    "compute_cid",
+]

--- a/implementations/python/generate.py
+++ b/implementations/python/generate.py
@@ -1,0 +1,18 @@
+from cid import CIDS_DIR, EXAMPLES_DIR, compute_cid
+
+
+def main() -> int:
+    CIDS_DIR.mkdir(exist_ok=True)
+    for example in sorted(EXAMPLES_DIR.iterdir()):
+        if example.is_dir():
+            continue
+        content = example.read_bytes()
+        cid = compute_cid(content)
+        destination = CIDS_DIR / cid
+        destination.write_bytes(content)
+        print(f"Wrote {destination.name} from {example.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/typescript/check.ts
+++ b/implementations/typescript/check.ts
@@ -1,0 +1,25 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { CIDS_DIR, computeCid } from "./cid";
+
+let mismatches = 0;
+let count = 0;
+
+for (const entry of readdirSync(CIDS_DIR)) {
+  const fullPath = `${CIDS_DIR}/${entry}`;
+  if (statSync(fullPath).isDirectory()) {
+    continue;
+  }
+  count += 1;
+  const content = readFileSync(fullPath);
+  const expected = computeCid(content);
+  if (expected !== entry) {
+    console.log(`${entry} should be ${expected}`);
+    mismatches += 1;
+  }
+}
+
+if (mismatches) {
+  console.error(`Found ${mismatches} mismatched CID file(s).`);
+  process.exit(1);
+}
+console.log(`All ${count} CID files match their contents.`);

--- a/implementations/typescript/cid.ts
+++ b/implementations/typescript/cid.ts
@@ -1,0 +1,32 @@
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const BASE_DIR = resolve(__dirname, "..", "..");
+export const EXAMPLES_DIR = join(BASE_DIR, "examples");
+export const CIDS_DIR = join(BASE_DIR, "cids");
+
+const toBase64Url = (buffer: Buffer): string =>
+  buffer
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+
+export const encodeLength = (length: number): string => {
+  const bytes = Buffer.alloc(6);
+  bytes.writeUIntBE(length, 0, 6);
+  return toBase64Url(bytes);
+};
+
+export const computeCid = (content: Buffer): string => {
+  const prefix = encodeLength(content.length);
+  const suffix =
+    content.length <= 64
+      ? toBase64Url(content)
+      : toBase64Url(createHash("sha512").update(content).digest());
+  return `${prefix}${suffix}`;
+};

--- a/implementations/typescript/generate.ts
+++ b/implementations/typescript/generate.ts
@@ -1,0 +1,15 @@
+import { mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { CIDS_DIR, EXAMPLES_DIR, computeCid } from "./cid";
+
+mkdirSync(CIDS_DIR, { recursive: true });
+
+for (const entry of readdirSync(EXAMPLES_DIR)) {
+  const fullPath = `${EXAMPLES_DIR}/${entry}`;
+  if (statSync(fullPath).isDirectory()) {
+    continue;
+  }
+  const content = readFileSync(fullPath);
+  const cid = computeCid(content);
+  writeFileSync(`${CIDS_DIR}/${cid}`, content);
+  console.log(`Wrote ${cid} from ${entry}`);
+}


### PR DESCRIPTION
## Summary
- add sample texts and CID-named copies for deterministic verification
- implement CID generation helpers and check scripts across Python, Node, Deno, JavaScript, TypeScript, and Java

## Testing
- python implementations/python/check.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918ff9280608331ac696a3f72319b59)