### PR TITLE
Add Go CID checker implementation

### DIFF
--- a/.github/workflows/cid-checks.yml
+++ b/.github/workflows/cid-checks.yml
@@ -75,3 +75,15 @@ jobs:
         run: javac implementations/java/*.java
       - name: Run Java CID check
         run: java -cp implementations/java Check
+
+  go:
+    name: Go CID check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Run Go CID check
+        working-directory: implementations/go
+        run: go run .

--- a/implementations/go/check.go
+++ b/implementations/go/check.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+func main() {
+	entries, err := os.ReadDir(CidsDir)
+	if err != nil {
+		fmt.Printf("Failed to read cids directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	mismatches := 0
+	count := 0
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		count++
+
+		path := filepath.Join(CidsDir, entry.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Printf("Failed to read %s: %v\n", entry.Name(), err)
+			mismatches++
+			continue
+		}
+
+		expected := computeCID(content)
+		if expected != entry.Name() {
+			fmt.Printf("%s should be %s\n", entry.Name(), expected)
+			mismatches++
+		}
+	}
+
+	if mismatches > 0 {
+		fmt.Printf("Found %d mismatched CID file(s).\n", mismatches)
+		os.Exit(1)
+	}
+
+	fmt.Printf("All %d CID files match their contents.\n", count)
+}

--- a/implementations/go/cid.go
+++ b/implementations/go/cid.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/binary"
+	"path/filepath"
+	"runtime"
+)
+
+var (
+	BaseDir     string
+	ExamplesDir string
+	CidsDir     string
+)
+
+func init() {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("unable to determine caller information")
+	}
+	BaseDir = filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+	ExamplesDir = filepath.Join(BaseDir, "examples")
+	CidsDir = filepath.Join(BaseDir, "cids")
+}
+
+func toBase64URL(data []byte) string {
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func encodeLength(length int) string {
+	var buffer [8]byte
+	binary.BigEndian.PutUint64(buffer[:], uint64(length))
+	return toBase64URL(buffer[2:])
+}
+
+func computeCID(content []byte) string {
+	prefix := encodeLength(len(content))
+
+	var suffix string
+	if len(content) <= 64 {
+		suffix = toBase64URL(content)
+	} else {
+		hash := sha512.Sum512(content)
+		suffix = toBase64URL(hash[:])
+	}
+
+	return prefix + suffix
+}

--- a/implementations/go/go.mod
+++ b/implementations/go/go.mod
@@ -1,0 +1,3 @@
+module cid
+
+go 1.22.0


### PR DESCRIPTION
## Summary
- add a Go implementation for computing CIDs
- add a Go-based checker that validates stored CID files
- wire the Go checker into the CID Checks workflow

## Testing
- cd implementations/go && go run .


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6919128fa7788331871237da379fcddc)