### PR TITLE
Add Ruby CID check implementation

### DIFF
--- a/.github/workflows/cid-checks.yml
+++ b/.github/workflows/cid-checks.yml
@@ -97,3 +97,14 @@ jobs:
       - name: Run Rust CID check
         working-directory: implementations/rust
         run: cargo run --release --quiet
+
+  ruby:
+    name: Ruby CID check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+      - name: Run Ruby CID check
+        run: ruby implementations/ruby/check.rb

--- a/implementations/ruby/check.rb
+++ b/implementations/ruby/check.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "cid"
+
+def main
+  mismatches = []
+  count = 0
+
+  entries = CIDS_DIR.children.select(&:file?).sort_by { |path| path.basename.to_s }
+
+  entries.each do |path|
+    count += 1
+    content = path.binread
+    expected = compute_cid(content)
+    actual = path.basename.to_s
+    mismatches << [actual, expected] if expected != actual
+  end
+
+  if mismatches.empty?
+    puts "All #{count} CID files match their contents."
+    return 0
+  end
+
+  puts "Found CID mismatches:"
+  mismatches.each do |actual, expected|
+    puts "- #{actual} should be #{expected}"
+  end
+  1
+end
+
+exit(main)

--- a/implementations/ruby/cid.rb
+++ b/implementations/ruby/cid.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "base64"
+require "digest"
+require "pathname"
+
+BASE_DIR = Pathname(__dir__).join("..", "..").realpath
+EXAMPLES_DIR = BASE_DIR.join("examples")
+CIDS_DIR = BASE_DIR.join("cids")
+
+def to_base64url(data)
+  Base64.urlsafe_encode64(data).delete("=")
+end
+
+def encode_length(length)
+  bytes = [length].pack("Q>")
+  to_base64url(bytes[-6, 6])
+end
+
+def compute_cid(content)
+  prefix = encode_length(content.bytesize)
+  suffix = if content.bytesize <= 64
+    to_base64url(content)
+  else
+    to_base64url(Digest::SHA512.digest(content))
+  end
+  prefix + suffix
+end
+


### PR DESCRIPTION
## Summary
- add Ruby utilities to compute and verify content IDs
- implement Ruby checker for existing CID files
- add Ruby job to the cid-checks workflow

## Testing
- ruby implementations/ruby/check.rb


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691915d00e748331bbc712521648a2b0)