### PR TITLE
Add PHP CID checker

### DIFF
--- a/.github/workflows/cid-checks.yml
+++ b/.github/workflows/cid-checks.yml
@@ -108,3 +108,14 @@ jobs:
           ruby-version: '3.3'
       - name: Run Ruby CID check
         run: ruby implementations/ruby/check.rb
+
+  php:
+    name: PHP CID check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - name: Run PHP CID check
+        run: php implementations/php/check.php

--- a/implementations/php/check.php
+++ b/implementations/php/check.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/cid.php';
+
+$entries = scandir(CIDS_DIR);
+if ($entries === false) {
+    fwrite(STDERR, "Unable to read cids directory.\n");
+    exit(1);
+}
+
+sort($entries);
+
+$mismatches = [];
+$count = 0;
+
+foreach ($entries as $entry) {
+    if ($entry === '.' || $entry === '..') {
+        continue;
+    }
+
+    $path = CIDS_DIR . DIRECTORY_SEPARATOR . $entry;
+    if (is_dir($path)) {
+        continue;
+    }
+
+    $content = file_get_contents($path);
+    if ($content === false) {
+        $mismatches[] = "$entry could not be read";
+        continue;
+    }
+
+    $count++;
+    $expected = compute_cid($content);
+    if ($expected !== $entry) {
+        $mismatches[] = sprintf('%s should be %s', $entry, $expected);
+    }
+}
+
+if ($mismatches) {
+    echo "Found CID mismatches:\n";
+    foreach ($mismatches as $message) {
+        echo "- {$message}\n";
+    }
+    exit(1);
+}
+
+echo "All {$count} CID files match their contents.\n";

--- a/implementations/php/cid.php
+++ b/implementations/php/cid.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+$baseDir = realpath(__DIR__ . '/../../');
+
+define('BASE_DIR', $baseDir === false ? '' : $baseDir);
+define('EXAMPLES_DIR', BASE_DIR . '/examples');
+define('CIDS_DIR', BASE_DIR . '/cids');
+
+function base64url_encode(string $data): string
+{
+    return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+}
+
+function encode_length(int $length): string
+{
+    $bytes = '';
+    for ($i = 5; $i >= 0; $i--) {
+        $bytes .= chr(($length >> ($i * 8)) & 0xFF);
+    }
+
+    return base64url_encode($bytes);
+}
+
+function compute_cid(string $content): string
+{
+    $prefix = encode_length(strlen($content));
+    if (strlen($content) <= 64) {
+        $suffix = base64url_encode($content);
+    } else {
+        $suffix = base64url_encode(hash('sha512', $content, true));
+    }
+
+    return $prefix . $suffix;
+}


### PR DESCRIPTION
## Summary
- add PHP implementation for computing content identifiers
- add a PHP CID check script to validate stored CIDs
- run the PHP CID verification as part of CI

## Testing
- php implementations/php/check.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691916bf0b8083319d60dfdbc6a0bf2f)