### PR TITLE
Add Bash CID implementation

### DIFF
--- a/.github/workflows/cid-checks.yml
+++ b/.github/workflows/cid-checks.yml
@@ -138,3 +138,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run Perl CID check
         run: perl implementations/perl/check.pl
+
+  bash:
+    name: Bash CID check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Bash CID check
+        run: bash implementations/bash/check.sh

--- a/implementations/bash/check.sh
+++ b/implementations/bash/check.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname -- "${BASH_SOURCE[0]}")/cid.sh"
+
+main() {
+  local mismatches=()
+  local count=0
+  while IFS= read -r -d '' path; do
+    ((count++))
+    actual=$(basename -- "$path")
+    expected=$(compute_cid "$path")
+    if [[ "$actual" != "$expected" ]]; then
+      mismatches+=("$path:$expected")
+    fi
+  done < <(find "$CIDS_DIR" -maxdepth 1 -type f -print0 | sort -z) || true
+
+  if (( ${#mismatches[@]} > 0 )); then
+    echo "Found CID mismatches:"
+    for mismatch in "${mismatches[@]}"; do
+      IFS=":" read -r path expected <<<"$mismatch"
+      echo "- $(basename -- "$path") should be $expected"
+    done
+    return 1
+  fi
+
+  echo "All $count CID files match their contents."
+}
+
+main "$@"

--- a/implementations/bash/cid.sh
+++ b/implementations/bash/cid.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+BASE_DIR=$(cd -- "$SCRIPT_DIR/../.." && pwd)
+EXAMPLES_DIR="$BASE_DIR/examples"
+CIDS_DIR="$BASE_DIR/cids"
+
+encode_length() {
+  local length=$1
+  printf '%012x' "$length" \
+    | perl -ne 'chomp; print pack("H*", $_)' \
+    | base64 \
+    | tr '+/' '-_' \
+    | tr -d '=\n'
+}
+
+compute_cid() {
+  local file=$1
+  local length suffix
+  length=$(wc -c <"$file")
+  if (( length <= 64 )); then
+    suffix=$(base64 "$file" | tr '+/' '-_' | tr -d '=\n')
+  else
+    suffix=$(sha512sum "$file" \
+      | awk '{print $1}' \
+      | perl -ne 'chomp; print pack("H*", $_)' \
+      | base64 \
+      | tr '+/' '-_' \
+      | tr -d '=\n')
+  fi
+  printf '%s%s\n' "$(encode_length "$length")" "$suffix"
+}
+
+export BASE_DIR
+export EXAMPLES_DIR
+export CIDS_DIR
+export -f encode_length
+export -f compute_cid

--- a/implementations/bash/generate.sh
+++ b/implementations/bash/generate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname -- "${BASH_SOURCE[0]}")/cid.sh"
+
+main() {
+  mkdir -p "$CIDS_DIR"
+  local example cid destination
+  while IFS= read -r -d '' example; do
+    cid=$(compute_cid "$example")
+    destination="$CIDS_DIR/$cid"
+    cp "$example" "$destination"
+    echo "Wrote $(basename -- "$destination") from $(basename -- "$example")"
+  done < <(find "$EXAMPLES_DIR" -maxdepth 1 -type f -print0 | sort -z) || true
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a Bash implementation for generating and verifying CIDs
- include the Bash checker in the CI workflow alongside existing languages

## Testing
- bash implementations/bash/check.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69191d149ed48331b98725ab841feb0e)