### PR TITLE
Add PowerShell CID checker

### DIFF
--- a/.github/workflows/cid-checks.yml
+++ b/.github/workflows/cid-checks.yml
@@ -139,6 +139,14 @@ jobs:
       - name: Run Perl CID check
         run: perl implementations/perl/check.pl
 
+  powershell:
+    name: PowerShell CID check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run PowerShell CID check
+        run: pwsh implementations/powershell/check.ps1
+
   bash:
     name: Bash CID check
     runs-on: ubuntu-latest

--- a/implementations/powershell/check.ps1
+++ b/implementations/powershell/check.ps1
@@ -1,0 +1,71 @@
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$repoRoot = Resolve-Path (Join-Path $scriptDir '..' '..')
+$cidsDir = Join-Path $repoRoot 'cids'
+
+function To-Base64Url {
+    param(
+        [byte[]] $Bytes
+    )
+
+    return [Convert]::ToBase64String($Bytes).TrimEnd('=') -replace '\+','-' -replace '/','_'
+}
+
+function Encode-Length {
+    param(
+        [int] $Length
+    )
+
+    $lengthBytes = New-Object byte[] 6
+    for ($i = 5; $i -ge 0; $i--) {
+        $shift = 8 * $i
+        $lengthBytes[5 - $i] = [byte](($Length -shr $shift) -band 0xFF)
+    }
+
+    return To-Base64Url -Bytes $lengthBytes
+}
+
+function Compute-Cid {
+    param(
+        [byte[]] $Content
+    )
+
+    $prefix = Encode-Length -Length $Content.Length
+
+    if ($Content.Length -le 64) {
+        $suffix = To-Base64Url -Bytes $Content
+    }
+    else {
+        $sha = [System.Security.Cryptography.SHA512]::Create()
+        $hash = $sha.ComputeHash($Content)
+        $suffix = To-Base64Url -Bytes $hash
+    }
+
+    return "$prefix$suffix"
+}
+
+function Main {
+    $mismatches = @()
+    $count = 0
+
+    Get-ChildItem -Path $cidsDir | Where-Object { -not $_.PSIsContainer } | Sort-Object Name | ForEach-Object {
+        $count++
+        $content = [IO.File]::ReadAllBytes($_.FullName)
+        $expected = Compute-Cid -Content $content
+        if ($_.Name -ne $expected) {
+            $mismatches += [PSCustomObject]@{ Actual = $_.Name; Expected = $expected }
+        }
+    }
+
+    if ($mismatches.Count -gt 0) {
+        Write-Output "Found CID mismatches:"
+        foreach ($entry in $mismatches) {
+            Write-Output "- $($entry.Actual) should be $($entry.Expected)"
+        }
+        return 1
+    }
+
+    Write-Output "All $count CID files match their contents."
+    return 0
+}
+
+exit (Main)


### PR DESCRIPTION
## Summary
- add a PowerShell implementation to compute and verify CIDs
- include the PowerShell checker in the cid-checks workflow

## Testing
- pwsh implementations/powershell/check.ps1 *(fails locally: pwsh not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69191e0b47b88331ba503b22e2dc3469)