### PR TITLE
Add Julia CID implementation

### DIFF
--- a/.github/workflows/cid-checks.yml
+++ b/.github/workflows/cid-checks.yml
@@ -88,6 +88,17 @@ jobs:
         working-directory: implementations/go
         run: go run .
 
+  julia:
+    name: Julia CID check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.10'
+      - name: Run Julia CID check
+        run: julia implementations/julia/check.jl
+
   csharp:
     name: C# CID check
     runs-on: ubuntu-latest

--- a/implementations/julia/check.jl
+++ b/implementations/julia/check.jl
@@ -1,0 +1,36 @@
+include("cid.jl")
+using .CID
+
+function main()
+    entries = sort(readdir(CID.CIDS_DIR))
+    mismatches = Vector{Tuple{String, String}}()
+    count = 0
+
+    for name in entries
+        path = joinpath(CID.CIDS_DIR, name)
+        if isdir(path)
+            continue
+        end
+
+        count += 1
+        content = read(path)
+        expected = CID.compute_cid(content)
+
+        if expected != name
+            push!(mismatches, (name, expected))
+        end
+    end
+
+    if !isempty(mismatches)
+        println("Found CID mismatches:")
+        for (actual, expected) in mismatches
+            println("- $actual should be $expected")
+        end
+        return 1
+    end
+
+    println("All $count CID files match their contents.")
+    return 0
+end
+
+exit(main())

--- a/implementations/julia/cid.jl
+++ b/implementations/julia/cid.jl
@@ -1,0 +1,33 @@
+module CID
+
+using SHA
+import Base64
+
+const BASE_DIR = normpath(joinpath(@__DIR__, "..", ".."))
+const EXAMPLES_DIR = joinpath(BASE_DIR, "examples")
+const CIDS_DIR = joinpath(BASE_DIR, "cids")
+
+function to_base64url(data::Vector{UInt8})
+    encoded = Base64.base64encode(data)
+    encoded = replace(encoded, "+" => "-", "/" => "_", "=" => "")
+    return encoded
+end
+
+function encode_length(length::Int)
+    bytes = Vector{UInt8}(undef, 6)
+    for i in 0:5
+        shift = (5 - i) * 8
+        bytes[i + 1] = UInt8((length >> shift) & 0xff)
+    end
+    return to_base64url(bytes)
+end
+
+function compute_cid(content::Vector{UInt8})
+    prefix = encode_length(length(content))
+    suffix = length(content) <= 64 ? to_base64url(content) : to_base64url(SHA.sha512(content))
+    return string(prefix, suffix)
+end
+
+export BASE_DIR, EXAMPLES_DIR, CIDS_DIR, compute_cid
+
+end

--- a/implementations/julia/generate.jl
+++ b/implementations/julia/generate.jl
@@ -1,0 +1,23 @@
+include("cid.jl")
+using .CID
+
+function main()
+    ispath(CID.CIDS_DIR) || mkpath(CID.CIDS_DIR)
+
+    for name in sort(readdir(CID.EXAMPLES_DIR))
+        path = joinpath(CID.EXAMPLES_DIR, name)
+        if isdir(path)
+            continue
+        end
+
+        content = read(path)
+        cid = CID.compute_cid(content)
+        destination = joinpath(CID.CIDS_DIR, cid)
+        write(destination, content)
+        println("Wrote $(basename(destination)) from $name")
+    end
+
+    return 0
+end
+
+exit(main())


### PR DESCRIPTION
## Summary
- add a Julia implementation for computing CIDs
- provide a generator for producing CID files from the examples directory
- run the Julia CID checker in CI alongside other languages

## Testing
- python implementations/python/check.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69192b0e1f108331bfa22111b23dd1da)