### PR TITLE
Add Dart CID check implementation

### DIFF
--- a/.github/workflows/cid-checks.yml
+++ b/.github/workflows/cid-checks.yml
@@ -88,6 +88,21 @@ jobs:
         working-directory: implementations/go
         run: go run .
 
+  dart:
+    name: Dart CID check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: Install Dart dependencies
+        working-directory: implementations/dart
+        run: dart pub get
+      - name: Run Dart CID check
+        working-directory: implementations/dart
+        run: dart run check.dart
+
   julia:
     name: Julia CID check
     runs-on: ubuntu-latest

--- a/implementations/dart/check.dart
+++ b/implementations/dart/check.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+import 'cid.dart';
+
+void main() {
+  final entries = cidsDir
+      .listSync()
+      .whereType<File>()
+      .toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+
+  var mismatches = <String>[];
+  for (final file in entries) {
+    final expected = computeCid(file.readAsBytesSync());
+    final actual = file.uri.pathSegments.last;
+    if (expected != actual) {
+      mismatches.add('$actual should be $expected');
+    }
+  }
+
+  if (mismatches.isNotEmpty) {
+    stdout.writeln('Found CID mismatches:');
+    for (final mismatch in mismatches) {
+      stdout.writeln('- $mismatch');
+    }
+    exitCode = 1;
+    return;
+  }
+
+  stdout.writeln('All ${entries.length} CID files match their contents.');
+}

--- a/implementations/dart/cid.dart
+++ b/implementations/dart/cid.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+
+final Directory _scriptDir = File(Platform.script.toFilePath()).parent;
+final Directory repoDir = _scriptDir.parent.parent;
+final Directory cidsDir = Directory('${repoDir.path}/cids');
+
+String _toBase64Url(Uint8List data) {
+  return base64UrlEncode(data).replaceAll('=', '');
+}
+
+String encodeLength(int length) {
+  final buffer = Uint8List(6);
+  var value = length;
+  for (var i = 5; i >= 0; i--) {
+    buffer[i] = value & 0xff;
+    value >>= 8;
+  }
+  return _toBase64Url(buffer);
+}
+
+String computeCid(List<int> content) {
+  final prefix = encodeLength(content.length);
+  final suffix = content.length <= 64
+      ? _toBase64Url(Uint8List.fromList(content))
+      : _toBase64Url(Uint8List.fromList(sha512.convert(content).bytes));
+  return '$prefix$suffix';
+}

--- a/implementations/dart/pubspec.yaml
+++ b/implementations/dart/pubspec.yaml
@@ -1,0 +1,7 @@
+name: cid_checker
+description: CID verification for 256t.org using Dart.
+version: 0.1.0
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+dependencies:
+  crypto: ^3.0.3


### PR DESCRIPTION
## Summary
- add a Dart CID computation helper and checker
- define Dart package metadata for dependencies
- integrate the Dart checker into the CID checks workflow

## Testing
- Not run (Dart SDK unavailable locally)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69193286dc608331904c082689ce49a5)