### PR TITLE
Add C CID checker

### DIFF
--- a/.github/workflows/cid-checks.yml
+++ b/.github/workflows/cid-checks.yml
@@ -223,3 +223,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run Bash CID check
         run: bash implementations/bash/check.sh
+
+  c:
+    name: C CID check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build C CID checker
+        run: gcc -std=c11 implementations/c/check.c implementations/c/cid.c -o implementations/c/check -lcrypto
+      - name: Run C CID check
+        run: ./implementations/c/check

--- a/implementations/c/check.c
+++ b/implementations/c/check.c
@@ -1,0 +1,204 @@
+#include "cid.h"
+
+#include <dirent.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#define CIDS_DIR "cids"
+
+struct mismatch {
+    char *name;
+    char *expected;
+};
+
+static int compare_strings(const void *a, const void *b) {
+    const char *lhs = *(const char *const *)a;
+    const char *rhs = *(const char *const *)b;
+    return strcmp(lhs, rhs);
+}
+
+static char *duplicate_string(const char *value) {
+    const size_t length = strlen(value) + 1;
+    char *copy = malloc(length);
+    if (!copy) {
+        return NULL;
+    }
+    memcpy(copy, value, length);
+    return copy;
+}
+
+static char *join_path(const char *left, const char *right) {
+    const size_t length = strlen(left) + strlen(right) + 2;
+    char *path = malloc(length);
+    if (!path) {
+        return NULL;
+    }
+    snprintf(path, length, "%s/%s", left, right);
+    return path;
+}
+
+static bool read_file(const char *path, unsigned char **data, size_t *length) {
+    FILE *file = fopen(path, "rb");
+    if (!file) {
+        return false;
+    }
+
+    if (fseek(file, 0, SEEK_END) != 0) {
+        fclose(file);
+        return false;
+    }
+
+    long size = ftell(file);
+    if (size < 0) {
+        fclose(file);
+        return false;
+    }
+
+    if (fseek(file, 0, SEEK_SET) != 0) {
+        fclose(file);
+        return false;
+    }
+
+    const size_t allocation = size > 0 ? (size_t)size : 1;
+    unsigned char *buffer = malloc(allocation);
+    if (!buffer) {
+        fclose(file);
+        return false;
+    }
+
+    const size_t read = size > 0 ? fread(buffer, 1, (size_t)size, file) : 0;
+    fclose(file);
+
+    if (read != (size_t)size) {
+        free(buffer);
+        return false;
+    }
+
+    *data = buffer;
+    *length = (size_t)size;
+    return true;
+}
+
+static bool is_regular_file(const char *path) {
+    struct stat info;
+    return stat(path, &info) == 0 && S_ISREG(info.st_mode);
+}
+
+int main(void) {
+    DIR *directory = opendir(CIDS_DIR);
+    if (!directory) {
+        fprintf(stderr, "Missing cids directory at %s\n", CIDS_DIR);
+        return 1;
+    }
+
+    char **files = NULL;
+    size_t file_count = 0;
+
+    struct dirent *entry;
+    while ((entry = readdir(directory)) != NULL) {
+        if (entry->d_name[0] == '.') {
+            continue;
+        }
+        char *path = join_path(CIDS_DIR, entry->d_name);
+        if (!path) {
+            closedir(directory);
+            for (size_t i = 0; i < file_count; ++i) {
+                free(files[i]);
+            }
+            free(files);
+            return 1;
+        }
+        if (!is_regular_file(path)) {
+            free(path);
+            continue;
+        }
+        free(path);
+
+        char **temp = realloc(files, (file_count + 1) * sizeof(char *));
+        if (!temp) {
+            closedir(directory);
+            free(files);
+            return 1;
+        }
+        files = temp;
+        files[file_count] = duplicate_string(entry->d_name);
+        if (!files[file_count]) {
+            closedir(directory);
+            for (size_t i = 0; i < file_count; ++i) {
+                free(files[i]);
+            }
+            free(files);
+            return 1;
+        }
+        ++file_count;
+    }
+    closedir(directory);
+
+    qsort(files, file_count, sizeof(char *), compare_strings);
+
+    struct mismatch *mismatches = NULL;
+    size_t mismatch_count = 0;
+
+    for (size_t i = 0; i < file_count; ++i) {
+        const char *filename = files[i];
+
+        char *path = join_path(CIDS_DIR, filename);
+        if (!path) {
+            fprintf(stderr, "Failed to build path for %s\n", filename);
+            continue;
+        }
+
+        unsigned char *content = NULL;
+        size_t length = 0;
+        if (!read_file(path, &content, &length)) {
+            fprintf(stderr, "Failed to read %s\n", path);
+            free(path);
+            continue;
+        }
+        free(path);
+
+        char *expected = compute_cid(content, length);
+        free(content);
+        if (!expected) {
+            fprintf(stderr, "Failed to compute CID for %s\n", filename);
+            continue;
+        }
+
+        if (strcmp(filename, expected) != 0) {
+            struct mismatch *temp = realloc(mismatches, (mismatch_count + 1) * sizeof(struct mismatch));
+            if (!temp) {
+                free(expected);
+                continue;
+            }
+            mismatches = temp;
+            mismatches[mismatch_count].name = duplicate_string(filename);
+            mismatches[mismatch_count].expected = expected;
+            ++mismatch_count;
+        } else {
+            free(expected);
+        }
+    }
+
+    for (size_t i = 0; i < file_count; ++i) {
+        free(files[i]);
+    }
+    free(files);
+
+    if (mismatch_count > 0) {
+        printf("Found CID mismatches:\n");
+        for (size_t i = 0; i < mismatch_count; ++i) {
+            printf("- %s should be %s\n", mismatches[i].name, mismatches[i].expected);
+            free(mismatches[i].name);
+            free(mismatches[i].expected);
+        }
+        free(mismatches);
+        return 1;
+    }
+
+    free(mismatches);
+    printf("All %zu CID files match their contents.\n", file_count);
+    return 0;
+}

--- a/implementations/c/cid.c
+++ b/implementations/c/cid.c
@@ -1,0 +1,102 @@
+#include "cid.h"
+
+#include <openssl/sha.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char kAlphabet[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+char *base64url_encode(const unsigned char *data, size_t length) {
+    const size_t full_chunks = length / 3;
+    const size_t remaining = length % 3;
+    size_t encoded_length = (full_chunks + (remaining ? 1 : 0)) * 4;
+
+    char *encoded = malloc(encoded_length + 1);
+    if (!encoded) {
+        return NULL;
+    }
+
+    size_t out = 0;
+    size_t i = 0;
+    while (i + 2 < length) {
+        const unsigned int triple = (data[i] << 16) | (data[i + 1] << 8) | data[i + 2];
+        encoded[out++] = kAlphabet[(triple >> 18) & 0x3F];
+        encoded[out++] = kAlphabet[(triple >> 12) & 0x3F];
+        encoded[out++] = kAlphabet[(triple >> 6) & 0x3F];
+        encoded[out++] = kAlphabet[triple & 0x3F];
+        i += 3;
+    }
+
+    if (remaining == 1) {
+        const unsigned int triple = data[i] << 16;
+        encoded[out++] = kAlphabet[(triple >> 18) & 0x3F];
+        encoded[out++] = kAlphabet[(triple >> 12) & 0x3F];
+        encoded[out++] = '=';
+        encoded[out++] = '=';
+    } else if (remaining == 2) {
+        const unsigned int triple = (data[i] << 16) | (data[i + 1] << 8);
+        encoded[out++] = kAlphabet[(triple >> 18) & 0x3F];
+        encoded[out++] = kAlphabet[(triple >> 12) & 0x3F];
+        encoded[out++] = kAlphabet[(triple >> 6) & 0x3F];
+        encoded[out++] = '=';
+    }
+
+    for (size_t j = 0; j < encoded_length; ++j) {
+        if (encoded[j] == '+') encoded[j] = '-';
+        if (encoded[j] == '/') encoded[j] = '_';
+    }
+
+    while (encoded_length > 0 && encoded[encoded_length - 1] == '=') {
+        --encoded_length;
+    }
+    encoded[encoded_length] = '\0';
+
+    return encoded;
+}
+
+char *encode_length(size_t length) {
+    unsigned char bytes[6] = {0};
+    for (int i = 0; i < 6; ++i) {
+        bytes[5 - i] = (unsigned char)((length >> (i * 8)) & 0xFF);
+    }
+    return base64url_encode(bytes, sizeof(bytes));
+}
+
+char *compute_cid(const unsigned char *content, size_t length) {
+    char *prefix = encode_length(length);
+    if (!prefix) {
+        return NULL;
+    }
+
+    char *suffix = NULL;
+    if (length <= 64) {
+        suffix = base64url_encode(content, length);
+    } else {
+        unsigned char digest[SHA512_DIGEST_LENGTH];
+        SHA512(content, length, digest);
+        suffix = base64url_encode(digest, SHA512_DIGEST_LENGTH);
+    }
+
+    if (!suffix) {
+        free(prefix);
+        return NULL;
+    }
+
+    const size_t prefix_len = strlen(prefix);
+    const size_t suffix_len = strlen(suffix);
+    char *cid = malloc(prefix_len + suffix_len + 1);
+    if (!cid) {
+        free(prefix);
+        free(suffix);
+        return NULL;
+    }
+
+    memcpy(cid, prefix, prefix_len);
+    memcpy(cid + prefix_len, suffix, suffix_len);
+    cid[prefix_len + suffix_len] = '\0';
+
+    free(prefix);
+    free(suffix);
+    return cid;
+}

--- a/implementations/c/cid.h
+++ b/implementations/c/cid.h
@@ -1,0 +1,10 @@
+#ifndef CID_H
+#define CID_H
+
+#include <stddef.h>
+
+char *base64url_encode(const unsigned char *data, size_t length);
+char *encode_length(size_t length);
+char *compute_cid(const unsigned char *content, size_t length);
+
+#endif  // CID_H


### PR DESCRIPTION
## Summary
- add a C implementation of CID computation and validation
- integrate the C checker into the CID Checks workflow

## Testing
- gcc -std=c11 implementations/c/check.c implementations/c/cid.c -o implementations/c/check -lcrypto
- ./implementations/c/check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69193971994883318b663507be6e801a)