### PR TITLE
Add Erlang CID implementation

### DIFF
--- a/.github/workflows/cid-checks.yml
+++ b/.github/workflows/cid-checks.yml
@@ -166,6 +166,18 @@ jobs:
       - name: Run Elixir CID check
         run: elixir implementations/elixir/check.exs
 
+  erlang:
+    name: Erlang CID check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Erlang
+        run: sudo apt-get update && sudo apt-get install -y erlang
+      - name: Compile Erlang CID checker
+        run: erlc -o implementations/erlang implementations/erlang/*.erl
+      - name: Run Erlang CID check
+        run: erl -noshell -pa implementations/erlang -s check run -s init stop
+
   julia:
     name: Julia CID check
     runs-on: ubuntu-latest

--- a/implementations/erlang/check.erl
+++ b/implementations/erlang/check.erl
@@ -1,0 +1,44 @@
+-module(check).
+-export([run/0, main/1]).
+
+main(_Args) ->
+    run().
+
+run() ->
+    {Mismatches, Count} = verify_cids(),
+    case Mismatches of
+        [] ->
+            io:format("All ~p CID files match their contents.~n", [Count]),
+            halt(0);
+        _ ->
+            lists:foreach(
+              fun({Actual, Expected}) ->
+                  io:format("~s should be ~s~n", [Actual, Expected])
+              end,
+              lists:reverse(Mismatches)),
+            io:format("Found ~p mismatched CID file(s).~n", [length(Mismatches)]),
+            halt(1)
+    end.
+
+verify_cids() ->
+    CidsDir = cid:cids_dir(),
+    {ok, Entries} = file:list_dir(CidsDir),
+    lists:foldl(
+      fun(Name, {Acc, Count}) ->
+          Path = filename:join(CidsDir, Name),
+          case filelib:is_regular(Path) of
+              true ->
+                  {ok, Content} = file:read_file(Path),
+                  Expected = cid:compute(Content),
+                  Actual = list_to_binary(Name),
+                  NewAcc = case Expected =:= Actual of
+                      true -> Acc;
+                      false -> [{Actual, Expected} | Acc]
+                  end,
+                  {NewAcc, Count + 1};
+              false ->
+                  {Acc, Count}
+          end
+      end,
+      {[], 0},
+      lists:sort(Entries)).

--- a/implementations/erlang/cid.erl
+++ b/implementations/erlang/cid.erl
@@ -1,0 +1,55 @@
+-module(cid).
+-export([base_dir/0, examples_dir/0, cids_dir/0, encode_length/1, to_base64url/1, compute/1, write_example_cids/0]).
+
+base_dir() ->
+    filename:dirname(filename:dirname(filename:dirname(code:which(?MODULE)))).
+
+examples_dir() ->
+    filename:join(base_dir(), "examples").
+
+cids_dir() ->
+    filename:join(base_dir(), "cids").
+
+encode_length(Length) when is_integer(Length), Length >= 0 ->
+    LengthBin = <<Length:48/unsigned-big>>,
+    to_base64url(LengthBin).
+
+to_base64url(Bin) when is_binary(Bin) ->
+    base64url(base64:encode(Bin));
+
+to_base64url(List) when is_list(List) ->
+    to_base64url(list_to_binary(List)).
+
+base64url(Encoded) ->
+    binary:replace(
+      binary:replace(
+        binary:replace(Encoded, <<"+">>, <<"-">>, [global]),
+        <<"/">>, <<"_">>, [global]),
+      <<"=">>, <<>>, [global]
+    ).
+
+compute(Content) when is_binary(Content) ->
+    Prefix = encode_length(byte_size(Content)),
+    Suffix = case byte_size(Content) =< 64 of
+        true -> to_base64url(Content);
+        false -> to_base64url(crypto:hash(sha512, Content))
+    end,
+    <<Prefix/binary, Suffix/binary>>;
+compute(Content) when is_list(Content) ->
+    compute(list_to_binary(Content)).
+
+write_example_cids() ->
+    filelib:ensure_dir(filename:join(cids_dir(), "placeholder")),
+    {ok, Entries} = file:list_dir(examples_dir()),
+    lists:foreach(fun(Name) ->
+        Path = filename:join(examples_dir(), Name),
+        case filelib:is_regular(Path) of
+            true ->
+                {ok, Content} = file:read_file(Path),
+                Cid = compute(Content),
+                ok = file:write_file(filename:join(cids_dir(), Cid), Content),
+                io:format("Wrote ~s from ~s~n", [Cid, Name]);
+            false ->
+                ok
+        end
+    end, lists:sort(Entries)).

--- a/implementations/erlang/generate.erl
+++ b/implementations/erlang/generate.erl
@@ -1,0 +1,9 @@
+-module(generate).
+-export([run/0, main/1]).
+
+main(_Args) ->
+    run().
+
+run() ->
+    cid:write_example_cids(),
+    halt(0).


### PR DESCRIPTION
## Summary
- add an Erlang implementation for computing and writing CIDs
- include a generator for example content files using the Erlang tools
- wire the Erlang CID checker into the workflow alongside other languages

## Testing
- erlc -o implementations/erlang implementations/erlang/*.erl
- erl -noshell -pa implementations/erlang -s check run -s init stop

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6919edf4bcc883318dd4c19ab6a44a37)