### PR TITLE
Add F# CID implementation and workflow check

### DIFF
--- a/.github/workflows/cid-checks.yml
+++ b/.github/workflows/cid-checks.yml
@@ -210,6 +210,17 @@ jobs:
       - name: Run C# CID check
         run: dotnet run --configuration Release --project implementations/csharp -- check
 
+  fsharp:
+    name: F# CID check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Run F# CID check
+        run: dotnet fsi implementations/fsharp/check.fsx
+
   cpp:
     name: C++ CID check
     runs-on: ubuntu-latest

--- a/implementations/fsharp/check.fsx
+++ b/implementations/fsharp/check.fsx
@@ -1,0 +1,38 @@
+#load "cid.fsx"
+
+open System
+open System.IO
+open Cid
+
+let main () =
+    if not (Directory.Exists(cidsDirectory)) then
+        eprintfn "CID directory not found at '%s'." cidsDirectory
+        1
+    else
+        let files =
+            Directory.GetFiles(cidsDirectory)
+            |> Array.filter File.Exists
+            |> Array.sort
+
+        let mismatches =
+            files
+            |> Array.choose (fun path ->
+                let name = Path.GetFileName path
+                let expected = File.ReadAllBytes path |> computeCid
+                if name = expected then
+                    None
+                else
+                    Some(name, expected))
+            |> Array.toList
+
+        if mismatches.IsEmpty then
+            printfn "All %d CID files match their contents." files.Length
+            0
+        else
+            printfn "Found CID mismatches:"
+            mismatches
+            |> List.iter (fun (actual, expected) -> printfn "- %s should be %s" actual expected)
+            1
+
+let exitCode = main ()
+exit exitCode

--- a/implementations/fsharp/cid.fsx
+++ b/implementations/fsharp/cid.fsx
@@ -1,0 +1,32 @@
+module Cid
+
+open System
+open System.IO
+open System.Security.Cryptography
+
+let baseDirectory =
+    Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", ".."))
+
+let examplesDirectory = Path.Combine(baseDirectory, "examples")
+
+let cidsDirectory = Path.Combine(baseDirectory, "cids")
+
+let private toBase64Url (data: byte[]) =
+    Convert.ToBase64String(data).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+
+let private encodeLength (length: int) =
+    let buffer = Array.zeroCreate<byte> 6
+    let value = uint64 length
+    for i in 0 .. buffer.Length - 1 do
+        buffer.[buffer.Length - 1 - i] <- byte (value >>> (8 * i))
+    toBase64Url buffer
+
+let computeCid (content: byte[]) =
+    let prefix = encodeLength content.Length
+    let suffix =
+        if content.Length <= 64 then
+            toBase64Url content
+        else
+            use sha = SHA512.Create()
+            content |> sha.ComputeHash |> toBase64Url
+    prefix + suffix

--- a/implementations/fsharp/generate.fsx
+++ b/implementations/fsharp/generate.fsx
@@ -1,0 +1,24 @@
+#load "cid.fsx"
+
+open System
+open System.IO
+open Cid
+
+let main () =
+    Directory.CreateDirectory(cidsDirectory) |> ignore
+    let files =
+        Directory.GetFiles(examplesDirectory)
+        |> Array.filter File.Exists
+        |> Array.sort
+
+    for example in files do
+        let content = File.ReadAllBytes example
+        let cid = computeCid content
+        let destination = Path.Combine(cidsDirectory, cid)
+        File.WriteAllBytes(destination, content)
+        printfn "Wrote %s from %s" (Path.GetFileName destination) (Path.GetFileName example)
+
+    0
+
+let exitCode = main ()
+exit exitCode


### PR DESCRIPTION
## Summary
- add an F# implementation for computing, generating, and verifying content identifiers
- wire the new F# checker into the CID Checks workflow

## Testing
- python implementations/python/check.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691a4e8e36d48331b3c9ab1ad4d0a8a0)