### PR TITLE
Add Emacs Lisp CID implementation and CI job

### DIFF
--- a/.github/workflows/cid-checks.yml
+++ b/.github/workflows/cid-checks.yml
@@ -310,6 +310,16 @@ jobs:
       - name: Run Perl CID check
         run: perl implementations/perl/check.pl
 
+  emacs-lisp:
+    name: Emacs Lisp CID check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Emacs
+        run: sudo apt-get update && sudo apt-get install -y emacs-nox
+      - name: Run Emacs Lisp CID check
+        run: emacs --batch -l implementations/emacs-lisp/check.el
+
   powershell:
     name: PowerShell CID check
     runs-on: ubuntu-latest

--- a/implementations/emacs-lisp/check.el
+++ b/implementations/emacs-lisp/check.el
@@ -1,0 +1,27 @@
+;;; check.el --- Verify CID files  -*- lexical-binding: t; -*-
+
+(load-file (expand-file-name "cid.el" (file-name-directory (or load-file-name buffer-file-name))))
+
+(defun cid-check-all ()
+  (let ((mismatches '())
+        (count 0))
+    (dolist (path (sort (directory-files cid-cids-dir t "^[^.]") #'string<))
+      (when (file-regular-p path)
+        (setq count (1+ count))
+        (let* ((actual (file-name-nondirectory path))
+               (expected (cid-compute (cid-read-file path))))
+          (unless (string= actual expected)
+            (push (cons actual expected) mismatches)))))
+    (if mismatches
+        (progn
+          (princ "Found CID mismatches:\n")
+          (dolist (pair (reverse mismatches))
+            (princ (format "- %s should be %s\n" (car pair) (cdr pair))))
+          1)
+      (princ (format "All %d CID files match their contents.\n" count))
+      0)))
+
+(let ((status (cid-check-all)))
+  (kill-emacs status))
+
+;;; check.el ends here

--- a/implementations/emacs-lisp/cid.el
+++ b/implementations/emacs-lisp/cid.el
@@ -1,0 +1,50 @@
+;;; cid.el --- Compute CIDs  -*- lexical-binding: t; -*-
+
+(defconst cid--base-dir
+  (expand-file-name "../.." (file-name-directory (or load-file-name buffer-file-name)))
+  "Repository root directory.")
+
+(defconst cid-examples-dir (expand-file-name "examples" cid--base-dir))
+(defconst cid-cids-dir (expand-file-name "cids" cid--base-dir))
+
+(defun cid--trim-padding (encoded)
+  "Remove trailing padding characters from ENCODED base64 string."
+  (let ((i (length encoded)))
+    (while (and (> i 0) (eq (aref encoded (1- i)) ?=))
+      (setq i (1- i)))
+    (substring encoded 0 i)))
+
+(defun cid--base64url (data)
+  "Return base64url encoding of DATA.
+DATA should be a unibyte string."
+  (let ((encoded (base64-encode-string data t)))
+    (setq encoded (cid--trim-padding encoded))
+    (setq encoded (subst-char-in-string ?+ ?- encoded t))
+    (subst-char-in-string ?/ ?_ encoded t)))
+
+(defun cid--encode-length (length)
+  "Encode LENGTH as a 6-byte big-endian base64url string."
+  (let ((bytes (make-string 6 0)))
+    (dotimes (i 6)
+      (aset bytes i (logand (lsh length (* -8 (- 5 i))) #xff)))
+    (cid--base64url bytes)))
+
+(defun cid-compute (content)
+  "Compute the CID for CONTENT bytes (unibyte string)."
+  (let* ((len (length content))
+         (prefix (cid--encode-length len))
+         (suffix (if (<= len 64)
+                     (cid--base64url content)
+                   (cid--base64url (secure-hash 'sha512 content nil nil t)))))
+    (concat prefix suffix)))
+
+(defun cid-read-file (path)
+  "Read file at PATH as a unibyte string."
+  (with-temp-buffer
+    (set-buffer-multibyte nil)
+    (insert-file-contents-literally path)
+    (buffer-string)))
+
+(provide 'cid)
+
+;;; cid.el ends here

--- a/implementations/emacs-lisp/generate.el
+++ b/implementations/emacs-lisp/generate.el
@@ -1,0 +1,23 @@
+;;; generate.el --- Generate CID files from examples  -*- lexical-binding: t; -*-
+
+(load-file (expand-file-name "cid.el" (file-name-directory (or load-file-name buffer-file-name))))
+
+(defun cid-generate ()
+  (make-directory cid-cids-dir t)
+  (dolist (path (sort (directory-files cid-examples-dir t "^[^.]") #'string<))
+    (when (file-regular-p path)
+      (let* ((content (cid-read-file path))
+             (cid (cid-compute content))
+             (destination (expand-file-name cid cid-cids-dir)))
+        (with-temp-buffer
+          (set-buffer-multibyte nil)
+          (insert content)
+          (write-region (point-min) (point-max) destination nil 'silent))
+        (princ (format "Wrote %s from %s\n" (file-name-nondirectory destination)
+                       (file-name-nondirectory path))))))
+  0)
+
+(let ((status (cid-generate)))
+  (kill-emacs status))
+
+;;; generate.el ends here


### PR DESCRIPTION
## Summary
- add an Emacs Lisp implementation for computing, generating, and checking CIDs
- wire the Emacs Lisp checker into the CI workflow

## Testing
- Not run (package installation unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691aa6642588833183d778b06fdaab71)