### PR TITLE
Add CMake CID checker

### DIFF
--- a/.github/workflows/cid-checks.yml
+++ b/.github/workflows/cid-checks.yml
@@ -403,6 +403,14 @@ jobs:
       - name: Run C CID check
         run: ./implementations/c/check
 
+  cmake:
+    name: CMake CID check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run CMake CID check
+        run: cmake -P implementations/cmake/check.cmake
+
   zig:
     name: Zig CID check
     runs-on: ubuntu-latest

--- a/implementations/cmake/check.cmake
+++ b/implementations/cmake/check.cmake
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.20)
+
+set(BASE_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
+set(CIDS_DIR "${BASE_DIR}/cids")
+
+set(PYTHON_CID_SCRIPT [=[
+from pathlib import Path
+import base64, hashlib, sys
+path = Path(sys.argv[1])
+data = path.read_bytes()
+encode = lambda b: base64.urlsafe_b64encode(b).decode().rstrip('=')
+prefix = encode(len(data).to_bytes(6, 'big'))
+if len(data) <= 64:
+    suffix = encode(data)
+else:
+    suffix = encode(hashlib.sha512(data).digest())
+print(prefix + suffix)
+]=])
+string(REPLACE ";" "\\;" PYTHON_CID_SCRIPT_ESCAPED "${PYTHON_CID_SCRIPT}")
+
+set(mismatches "")
+set(count 0)
+
+file(GLOB cid_files "${CIDS_DIR}/*")
+list(SORT cid_files)
+
+foreach(path IN LISTS cid_files)
+  if(IS_DIRECTORY "${path}")
+    continue()
+  endif()
+  math(EXPR count "${count} + 1")
+  get_filename_component(filename "${path}" NAME)
+
+  execute_process(
+    COMMAND python -c "${PYTHON_CID_SCRIPT_ESCAPED}" "${path}"
+    OUTPUT_VARIABLE expected
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  if(NOT "${filename}" STREQUAL "${expected}")
+    list(APPEND mismatches "${filename}|${expected}")
+  endif()
+endforeach()
+
+if(mismatches)
+  message("Found CID mismatches:")
+  foreach(entry IN LISTS mismatches)
+    string(REPLACE "|" ";" parts "${entry}")
+    list(GET parts 0 actual)
+    list(GET parts 1 expected)
+    message(" - ${actual} should be ${expected}")
+  endforeach()
+  message(FATAL_ERROR "CID mismatches detected")
+else()
+  message(STATUS "All ${count} CID files match their contents.")
+endif()


### PR DESCRIPTION
## Summary
- add a CMake-based CID checker that validates existing CID files
- include the new checker in the CID Checks workflow

## Testing
- cmake -P implementations/cmake/check.cmake

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691aa9328bcc83318e0d4dd83f36f4d8)