### PR TITLE
Fix 256t.org root redirect to index.html

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,12 @@ name = "256t-org-site"
 main = "worker.js"
 compatibility_date = "2024-01-01"
 
+# Route all 256t.org traffic through this worker
+routes = [
+  { pattern = "256t.org/*", zone_name = "256t.org" },
+  { pattern = "www.256t.org/*", zone_name = "256t.org" }
+]
+
 # Bind the R2 bucket to the worker
 [[r2_buckets]]
 binding = "BUCKET"


### PR DESCRIPTION
The worker was deployed but not receiving traffic because wrangler.toml lacked the routes configuration. Without routes, requests to 256t.org/ went directly to R2 (returning 404) instead of through the worker that rewrites root path to index.html.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured routing for 256t.org and www.256t.org domains
  * Set up R2 storage bucket configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->