### PR TITLE
Fix 256t.org root redirect to index.html

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,7 +4,9 @@ compatibility_date = "2024-01-01"
 
 # Route all 256t.org traffic through this worker
 routes = [
+  { pattern = "256t.org", zone_name = "256t.org" },
   { pattern = "256t.org/*", zone_name = "256t.org" },
+  { pattern = "www.256t.org", zone_name = "256t.org" },
   { pattern = "www.256t.org/*", zone_name = "256t.org" }
 ]
 


### PR DESCRIPTION
The route pattern "256t.org/*" was not matching the bare root URL "256t.org/" because the wildcard requires at least one character after the slash. Added routes without the wildcard to ensure the root path is handled by the worker and serves index.html.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated domain routing configuration to support root domain access alongside existing path-based routing for primary and www domains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->